### PR TITLE
Remove time horizon calculations and old prod endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ wheels/
 
 # Virtual environments
 .venv
+
+.DS_Store

--- a/app/app.py
+++ b/app/app.py
@@ -28,22 +28,6 @@ def get_rps_ds():
     return ds
 
 
-def get_old_prod():
-    import icechunk
-    import xarray as xr
-
-    storage = icechunk.s3_storage(
-        bucket="carbonplan-ocr",
-        prefix="output/fire-risk/tensor/prod/template.icechunk",
-        region="us-west-2",
-        anonymous=True,
-    )
-    repo = icechunk.Repository.open(storage)
-    session = repo.readonly_session("main")
-    ds = xr.open_zarr(session.store, consolidated=False)
-    return ds
-
-
 def get_ds(branch: str, production_version: str | None = None):
     with logfire.span(f"Loading dataset for branch: {branch}"):
         import icechunk
@@ -97,7 +81,6 @@ def xpublish_app():
     datasets: dict[str, xr.Dataset] = {
         "qa": get_ds(branch="qa"),
         "staging": get_ds(branch="staging"),
-        "prod": get_old_prod(),
         "RPS": get_rps_ds(),
     }
 

--- a/app/app.py
+++ b/app/app.py
@@ -11,13 +11,6 @@ from xpublish_wms import CfWmsPlugin
 from xpublish import hookimpl
 
 
-def apply_time_horizon(ds: xr.Dataset, var: str) -> xr.Dataset:
-    ds[f"{var}_horizon_1"] = ds[var]
-    ds[f"{var}_horizon_15"] = (1 - (1 - (ds[var] / 100.0)) ** 15) * 100
-    ds[f"{var}_horizon_30"] = (1 - (1 - (ds[var] / 100.0)) ** 30) * 100
-    return ds
-
-
 def get_rps_ds():
     import icechunk
     import xarray as xr
@@ -31,9 +24,6 @@ def get_rps_ds():
     repo = icechunk.Repository.open(storage)
     session = repo.readonly_session("main")
     ds = xr.open_zarr(session.store, consolidated=False)[["RPS"]]
-    for var in list(ds):
-        logfire.info(f"Applying time horizon to variable: {var}")
-        ds = apply_time_horizon(ds, var)
 
     return ds
 
@@ -51,8 +41,6 @@ def get_old_prod():
     repo = icechunk.Repository.open(storage)
     session = repo.readonly_session("main")
     ds = xr.open_zarr(session.store, consolidated=False)
-    for var in list(ds):
-        ds = apply_time_horizon(ds, var)
     return ds
 
 
@@ -80,12 +68,6 @@ def get_ds(branch: str, production_version: str | None = None):
 
             with logfire.span("opening xarray dataset from icechunk repository"):
                 ds = xr.open_zarr(session.store, consolidated=False)
-
-                with logfire.span("applying time horizons"):
-                    for var in list(ds):
-                        logfire.info(f"Applying time horizon to variable: {var}")
-                        ds = apply_time_horizon(ds, var)
-
                 return ds
 
 


### PR DESCRIPTION
This removes the time horizon calculations, since we're not planning on visualizing those on the map going forward. I also cleaned up the old and unused `prod` endpoint. 

We'll want to wait until the horizon removal is live in the prod frontend before merging this.